### PR TITLE
Separate "included" and "exact" comparison diff messages

### DIFF
--- a/src/__tests__/fuzzySearch.test.ts
+++ b/src/__tests__/fuzzySearch.test.ts
@@ -1,0 +1,22 @@
+import {fuzzySearch} from '../fuzzySearch'
+
+describe('fuzzySearch', () => {
+  it('finds a close word in a group of words', async () => {
+    const sentence = 'The quick brown fox jumped over the lazy dog.'
+    expect(fuzzySearch(sentence, 'fxo')).toBe('fox')
+  }, 10000)
+
+  it('finds a line in an input', async () => {
+    const input =
+      'f1.numerator    = [a]\n' +
+      'f1.denominator  = [c]\n' +
+      'f1              = ( a ) / ( c )\n' +
+      'f2              = ( b miles ) / ( hour )\n' +
+      'f3              = ( x y hour ) / ( b )\n' +
+      'f4              = ( ) / ( )\n' +
+      'f1 * f2         = ( a b miles ) / ( c hour )\n' +
+      'f3 * f2         = ( x y miles ) / ( )\n' +
+      'f1 * f4         = ( a ) / ( c )'
+    expect(fuzzySearch(input, 'f1              = a / c')).toBe('f1              = ( a )')
+  }, 10000)
+})

--- a/src/__tests__/fuzzySearch.test.ts
+++ b/src/__tests__/fuzzySearch.test.ts
@@ -3,7 +3,7 @@ import {fuzzySearch} from '../fuzzySearch'
 describe('fuzzySearch', () => {
   it('finds a close word in a group of words', async () => {
     const sentence = 'The quick brown fox jumped over the lazy dog.'
-    expect(fuzzySearch(sentence, 'fxo')).toBe('fox')
+    expect(fuzzySearch(sentence, 'brwon')).toBe('brown')
   }, 10000)
 
   it('finds a line in an input', async () => {

--- a/src/fuzzySearch.ts
+++ b/src/fuzzySearch.ts
@@ -1,5 +1,5 @@
 /** Performs a fuzzy search over string input to find the closest matching item */
-export const fuzzySearch = (input: string, toFind: string): [number, string] => {
+export const fuzzySearch = (input: string, toFind: string): string => {
   const windows = toWindows(input.replace(/\r?\n/g, ' '), toFind.length)
 
   const firstDistance = [0, jaroSimilarity(windows[0], toFind)]
@@ -9,7 +9,7 @@ export const fuzzySearch = (input: string, toFind: string): [number, string] => 
     return prev[1] < distance ? [index, distance] : prev
   }, firstDistance)[0]
 
-  return [closestIndex, windows[closestIndex]]
+  return windows[closestIndex]
 }
 
 /**

--- a/src/fuzzySearch.ts
+++ b/src/fuzzySearch.ts
@@ -98,5 +98,5 @@ const jaroWinklerSimilarity = (str1: string, str2: string): number => {
   }
 
   // 0.1 is based on Winkler's original work. Can be any value in the range (0, 0.25]
-  return jaro + prefixLength * 0.25 * (1 - jaro)
+  return jaro + prefixLength * 0.1 * (1 - jaro)
 }

--- a/src/fuzzySearch.ts
+++ b/src/fuzzySearch.ts
@@ -6,6 +6,7 @@ export const fuzzySearch = (input: string, toFind: string): string => {
 
   const closestIndex = windows.reduce((prev, curr, index) => {
     const score = jaroWinklerSimilarity(curr, toFind)
+    console.log(curr + ' : ' + score)
     return prev[1] < score ? [index, score] : prev
   }, firstDistance)[0]
 
@@ -49,6 +50,7 @@ const jaroWinklerSimilarity = (str1: string, str2: string): number => {
   const len2 = str2.length
 
   // Max distance between characters to be considered matching
+  // This will cause inaccuracies with shorter words (min length for some accuracy is 4)
   const maxDist = Math.floor(Math.max(len1, len2) / 2) - 1
 
   let matches = 0
@@ -96,5 +98,5 @@ const jaroWinklerSimilarity = (str1: string, str2: string): number => {
   }
 
   // 0.1 is based on Winkler's original work. Can be any value in the range (0, 0.25]
-  return jaro + prefixLength * 0.1 * (1 - jaro)
+  return jaro + prefixLength * 0.25 * (1 - jaro)
 }

--- a/src/fuzzySearch.ts
+++ b/src/fuzzySearch.ts
@@ -6,7 +6,6 @@ export const fuzzySearch = (input: string, toFind: string): string => {
 
   const closestIndex = windows.reduce((prev, curr, index) => {
     const score = jaroWinklerSimilarity(curr, toFind)
-    console.log(curr + ' : ' + score)
     return prev[1] < score ? [index, score] : prev
   }, firstDistance)[0]
 

--- a/src/fuzzySearch.ts
+++ b/src/fuzzySearch.ts
@@ -1,0 +1,89 @@
+/** Performs a fuzzy search over string input to find the closest matching item */
+export const fuzzySearch = (input: string, toFind: string): [number, string] => {
+  const windows = toWindows(input.replace(/\r?\n/g, ' '), toFind.length)
+
+  const firstDistance = [0, jaroSimilarity(windows[0], toFind)]
+
+  const closestIndex = windows.reduce((prev, curr, index) => {
+    const distance = jaroSimilarity(curr, toFind)
+    return prev[1] < distance ? [index, distance] : prev
+  }, firstDistance)[0]
+
+  return [closestIndex, windows[closestIndex]]
+}
+
+/**
+ * Naive implementation to create windows over the input string
+ * Returned array is of size N - S + 1 where N is the amount of characters in the string
+ * and S is the required size of the window
+ *
+ * If the input is smaller than the requested size, an array containing
+ * the input will be returned
+ */
+
+const toWindows = (input: string, size: number): string[] => {
+  if (size > input.length) {
+    return [input]
+  }
+  const result = []
+  const lastWindow = input.length - size
+  for (let i = 0; i <= lastWindow; i++) {
+    result.push(input.slice(i, i + size))
+  }
+
+  return result
+}
+
+/**
+ * Calculates the Jaro Similarity between two strings.
+ * The range is from 0 to 1 where 0 means there is no similarity and 1 means they are equal.
+ * Algorithm described here: https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance
+ */
+const jaroSimilarity = (str1: string, str2: string): number => {
+  if (str1 == str2) return 1.0
+
+  const len1 = str1.length
+  const len2 = str2.length
+
+  // Max distance between characters to be considered matching
+  const maxDist = Math.floor(Math.max(len1, len2) / 2) - 1
+
+  let matches = 0
+  let transpositions = 0
+
+  const str1Matches = Array(len1).fill(false)
+  const str2Matches = Array(len2).fill(false)
+
+  // Iterate through every character of str1
+  for (let i = 0; i < len1; i++) {
+    // Iterate over a window of characters in str2 with a max width of maxDist * 2
+    for (let j = Math.max(0, i - maxDist); j < Math.min(len2, i + maxDist + 1); j++) {
+      // If the characters are equal and the second has not been matched yet, consider them a match
+      if (str1.charAt(i) === str2.charAt(j) && !str2Matches[j]) {
+        str1Matches[i] = true
+        str2Matches[j] = true
+        matches += 1
+
+        // Found a match! Break and move to the next character
+        break
+      }
+    }
+  }
+
+  // Return 0 if not a single match was found. Considered to have no similarity
+  if (matches == 0) return 0
+
+  let k = 0
+
+  // Go through the matches and calculate the total transpositions
+  for (let i = 0; i < len1; i++) {
+    if (str1Matches[i]) {
+      while (!str2Matches[k]) k++
+      if (str1.charAt(i) != str2.charAt(k++)) transpositions++
+    }
+  }
+
+  transpositions /= 2
+
+  return (matches / len1 + matches / len2 + (matches - transpositions) / matches) / 3.0
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -314,6 +314,7 @@ const runCommand = async (test: Test, cwd: string, timeout: number) => {
     result.push('')
     result.push('🟥EXPECTED: "' + expected + '"')
 
+    // We do not want to consider line endings in the number in character counts
     const closestIndex = actual.replace(/\r?\n/g, '').indexOf(closest[1])
     let charCount = 0
     let currLine = 1
@@ -322,7 +323,7 @@ const runCommand = async (test: Test, cwd: string, timeout: number) => {
       currLine++
     }
 
-    result.push('🟥 CLOSEST: "' + closest[1] + '" starting on line ' + currLine + ' character pos ' + closestIndex)
+    result.push('🟥 CLOSEST: "' + closest[1] + '" starting on line ' + currLine + ' pos ' + closestIndex)
     result.push('')
 
     return result.join(os.EOL)

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -315,7 +315,7 @@ const runCommand = async (test: Test, cwd: string, timeout: number) => {
     result.push('🟥EXPECTED: "' + expected + '"')
 
     // We do not want to consider line endings in the number in character counts
-    const closestIndex = actual.replace(/\r?\n/g, '').indexOf(closest[1])
+    const closestIndex = actual.replace(/\r?\n/g, '').indexOf(closest)
     let charCount = 0
     let currLine = 1
     while (charCount < closestIndex) {
@@ -323,7 +323,7 @@ const runCommand = async (test: Test, cwd: string, timeout: number) => {
       currLine++
     }
 
-    result.push('🟥 CLOSEST: "' + closest[1] + '" starting on line ' + currLine + ' pos ' + closestIndex)
+    result.push('🟥 CLOSEST: "' + closest + '" starting on line ' + currLine + ' pos ' + closestIndex)
     result.push('')
 
     return result.join(os.EOL)


### PR DESCRIPTION
# Description

This PR aims to provide separate error messages for `included` and `exact` for clearer output on tests using `included`. When an `included` test fails, the actual input will be fuzzy searched for the text it should include. It then displays the expected text and the closest match it could find.

The fuzzy searching algorithm creates windows over the input and finds the best match using the [Jaro-Winkler Similarity](https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance). 

### Considerations
- Instead of using a self-implemented algorithm, a proven library such as [Fuse.js](https://www.fusejs.io/) could be used.
- Jaro-Winkler only considers transpositions and a prefix of up to four characters. Through my own testing, it seemed the most accurate but [other staple algorithms](https://en.wikipedia.org/wiki/Edit_distance#Types_of_edit_distance) could be used.

# How Has This Been Tested?

This has been tested with the two initial tests found in `fuzzySearch.test.ts` along with other tests performed locally from homework assignments.

